### PR TITLE
Add Cloudinary integration with config and reusable service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Cloudinary environment configuration (do not commit sensitive keys)
+.env
+
 # Compiled class file
 *.class
 

--- a/pom.xml
+++ b/pom.xml
@@ -30,40 +30,25 @@
         <java.version>17</java.version>
     </properties>
     <dependencies>
+
+        <!-- == CORE SPRING BOOT STARTERS == -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-mail</artifactId>
+            <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
+
+        <!-- == SECURITY & AUTHENTICATION == -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-security</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-validation</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.postgresql</groupId>
-            <artifactId>postgresql</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.projectlombok</groupId>
-            <artifactId>lombok</artifactId>
-            <version>1.18.32</version>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-test</artifactId>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework.security</groupId>
@@ -75,11 +60,58 @@
             <artifactId>java-jwt</artifactId>
             <version>4.4.0</version>
         </dependency>
+
+        <!-- == DATABASE == -->
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <!-- == CLOUDINARY INTEGRATION == -->
+        <dependency>
+            <groupId>com.cloudinary</groupId>
+            <artifactId>cloudinary-http5</artifactId>
+            <version>2.0.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.cloudinary</groupId>
+            <artifactId>cloudinary-taglib</artifactId>
+            <version>2.0.0</version>
+        </dependency>
+        <dependency>
+            <groupId>io.github.cdimascio</groupId>
+            <artifactId>dotenv-java</artifactId>
+            <version>2.2.4</version>
+        </dependency>
+
+        <!-- == EMAIL SUPPORT == -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-mail</artifactId>
+        </dependency>
+
+        <!-- == DOCUMENTATION (Swagger/OpenAPI) == -->
         <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
             <version>2.2.0</version>
         </dependency>
+
+        <!-- == LOMBOK == -->
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>1.18.32</version>
+        </dependency>
+
+        <!-- == TESTING == -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/src/main/java/hu/progmasters/bskinteriordesignbackend/cloudinary/CloudinaryService.java
+++ b/src/main/java/hu/progmasters/bskinteriordesignbackend/cloudinary/CloudinaryService.java
@@ -1,0 +1,28 @@
+package hu.progmasters.bskinteriordesignbackend.cloudinary;
+
+
+import com.cloudinary.Cloudinary;
+import com.cloudinary.utils.ObjectUtils;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.Map;
+
+@Service
+public class CloudinaryService {
+
+    private final Cloudinary cloudinary;
+
+    public CloudinaryService(Cloudinary cloudinary) {
+        this.cloudinary = cloudinary;
+    }
+
+    public String uploadImage(MultipartFile file) throws IOException {
+        Map uploadResult = cloudinary.uploader().upload(file.getBytes(), ObjectUtils.emptyMap());
+        return uploadResult.get("secure_url").toString();
+    }
+}
+
+
+

--- a/src/main/java/hu/progmasters/bskinteriordesignbackend/config/CloudinaryConfig.java
+++ b/src/main/java/hu/progmasters/bskinteriordesignbackend/config/CloudinaryConfig.java
@@ -1,0 +1,18 @@
+package hu.progmasters.bskinteriordesignbackend.config;
+
+import com.cloudinary.Cloudinary;
+import io.github.cdimascio.dotenv.Dotenv;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class CloudinaryConfig {
+
+    @Bean
+    public Cloudinary cloudinary() {
+        Dotenv dotenv = Dotenv.load();
+        String cloudinaryUrl = dotenv.get("CLOUDINARY_URL");
+        return new Cloudinary(cloudinaryUrl);
+    }
+}
+


### PR DESCRIPTION
### Summary
This PR introduces Cloudinary integration for image upload, including:

- `.env` configuration with secure URL
- `.gitignore` update to exclude sensitive `.env` file
- `CloudinaryConfig` for reusable bean
- `CloudinaryService` for image upload via MultipartFile

### Motivation
Cloudinary will be used across multiple entities (e.g. gallery, about), so a modular and reusable setup was required.