### PR TITLE
Feature/gallery

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.5.6</version>
+        <version>3.2.5</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>hu.progmasters</groupId>
@@ -95,7 +95,7 @@
         <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-            <version>2.2.0</version>
+            <version>2.1.0</version>
         </dependency>
 
         <!-- == LOMBOK == -->

--- a/src/main/java/hu/progmasters/bskinteriordesignbackend/cloudinary/CloudinaryService.java
+++ b/src/main/java/hu/progmasters/bskinteriordesignbackend/cloudinary/CloudinaryService.java
@@ -3,6 +3,8 @@ package hu.progmasters.bskinteriordesignbackend.cloudinary;
 
 import com.cloudinary.Cloudinary;
 import com.cloudinary.utils.ObjectUtils;
+import hu.progmasters.bskinteriordesignbackend.cloudinary.model.dto.CloudinaryUploadResultDto;
+import hu.progmasters.bskinteriordesignbackend.exception.CloudinaryDeleteException;
 import hu.progmasters.bskinteriordesignbackend.exception.CloudinaryUploadException;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
@@ -19,15 +21,25 @@ public class CloudinaryService {
         this.cloudinary = cloudinary;
     }
 
-    public String uploadImage(MultipartFile file) {
+    public CloudinaryUploadResultDto uploadImage(MultipartFile file) {
         try {
             Map uploadResult = cloudinary.uploader().upload(file.getBytes(), ObjectUtils.emptyMap());
-            return uploadResult.get("secure_url").toString();
+            String imageUrl = uploadResult.get("secure_url").toString();
+            String publicId = uploadResult.get("public_id").toString();
+
+            return new CloudinaryUploadResultDto(imageUrl, publicId);
         } catch (IOException e) {
             throw new CloudinaryUploadException("Failed to upload image to Cloudinary", e);
         }
     }
 
+    public void deleteImage(String publicId) {
+        try {
+            cloudinary.uploader().destroy(publicId, ObjectUtils.emptyMap());
+        } catch (IOException e) {
+            throw new CloudinaryDeleteException("Failed to delete image from Cloudinary", e);
+        }
+    }
 }
 
 

--- a/src/main/java/hu/progmasters/bskinteriordesignbackend/cloudinary/CloudinaryService.java
+++ b/src/main/java/hu/progmasters/bskinteriordesignbackend/cloudinary/CloudinaryService.java
@@ -3,6 +3,7 @@ package hu.progmasters.bskinteriordesignbackend.cloudinary;
 
 import com.cloudinary.Cloudinary;
 import com.cloudinary.utils.ObjectUtils;
+import hu.progmasters.bskinteriordesignbackend.exception.CloudinaryUploadException;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -18,10 +19,15 @@ public class CloudinaryService {
         this.cloudinary = cloudinary;
     }
 
-    public String uploadImage(MultipartFile file) throws IOException {
-        Map uploadResult = cloudinary.uploader().upload(file.getBytes(), ObjectUtils.emptyMap());
-        return uploadResult.get("secure_url").toString();
+    public String uploadImage(MultipartFile file) {
+        try {
+            Map uploadResult = cloudinary.uploader().upload(file.getBytes(), ObjectUtils.emptyMap());
+            return uploadResult.get("secure_url").toString();
+        } catch (IOException e) {
+            throw new CloudinaryUploadException("Failed to upload image to Cloudinary", e);
+        }
     }
+
 }
 
 

--- a/src/main/java/hu/progmasters/bskinteriordesignbackend/cloudinary/model/dto/CloudinaryUploadResultDto.java
+++ b/src/main/java/hu/progmasters/bskinteriordesignbackend/cloudinary/model/dto/CloudinaryUploadResultDto.java
@@ -1,0 +1,19 @@
+package hu.progmasters.bskinteriordesignbackend.cloudinary.model.dto;
+
+public class CloudinaryUploadResultDto {
+    private final String imageUrl;
+    private final String publicId;
+
+    public CloudinaryUploadResultDto(String imageUrl, String publicId) {
+        this.imageUrl = imageUrl;
+        this.publicId = publicId;
+    }
+
+    public String getImageUrl() {
+        return imageUrl;
+    }
+
+    public String getPublicId() {
+        return publicId;
+    }
+}

--- a/src/main/java/hu/progmasters/bskinteriordesignbackend/exception/CloudinaryDeleteException.java
+++ b/src/main/java/hu/progmasters/bskinteriordesignbackend/exception/CloudinaryDeleteException.java
@@ -1,0 +1,13 @@
+package hu.progmasters.bskinteriordesignbackend.exception;
+
+public class CloudinaryDeleteException extends RuntimeException {
+
+    public CloudinaryDeleteException(String message) {
+        super(message);
+    }
+
+    public CloudinaryDeleteException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+}

--- a/src/main/java/hu/progmasters/bskinteriordesignbackend/exception/CloudinaryUploadException.java
+++ b/src/main/java/hu/progmasters/bskinteriordesignbackend/exception/CloudinaryUploadException.java
@@ -1,0 +1,13 @@
+package hu.progmasters.bskinteriordesignbackend.exception;
+
+public class CloudinaryUploadException extends RuntimeException {
+
+    public CloudinaryUploadException(String message) {
+        super(message);
+    }
+
+    public CloudinaryUploadException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}
+

--- a/src/main/java/hu/progmasters/bskinteriordesignbackend/exception/GalleryImageNotFoundException.java
+++ b/src/main/java/hu/progmasters/bskinteriordesignbackend/exception/GalleryImageNotFoundException.java
@@ -1,0 +1,8 @@
+package hu.progmasters.bskinteriordesignbackend.exception;
+
+public class GalleryImageNotFoundException extends RuntimeException {
+
+    public GalleryImageNotFoundException(Long id) {
+        super("Gallery image not found with ID: " + id);
+    }
+}

--- a/src/main/java/hu/progmasters/bskinteriordesignbackend/exception/GlobalExceptionHandler.java
+++ b/src/main/java/hu/progmasters/bskinteriordesignbackend/exception/GlobalExceptionHandler.java
@@ -1,0 +1,30 @@
+package hu.progmasters.bskinteriordesignbackend.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(CloudinaryUploadException.class)
+    public ResponseEntity<String> handleCloudinaryUploadException(CloudinaryUploadException ex) {
+        return ResponseEntity.status(HttpStatus.BAD_GATEWAY)
+                .body("Image upload failed: " + ex.getMessage());
+    }
+
+    @ExceptionHandler(AboutEntityNotFoundException.class)
+    public ResponseEntity<String> handleAboutEntityNotFoundException(AboutEntityNotFoundException ex) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(ex.getMessage());
+    }
+
+    @ExceptionHandler(GalleryImageNotFoundException.class)
+    public ResponseEntity<String> handleGalleryImageNotFoundException(GalleryImageNotFoundException ex) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(ex.getMessage());
+    }
+}
+
+

--- a/src/main/java/hu/progmasters/bskinteriordesignbackend/gallery/controller/GalleryImageController.java
+++ b/src/main/java/hu/progmasters/bskinteriordesignbackend/gallery/controller/GalleryImageController.java
@@ -4,18 +4,19 @@ import hu.progmasters.bskinteriordesignbackend.gallery.model.dto.GalleryImageRes
 import hu.progmasters.bskinteriordesignbackend.gallery.model.dto.GalleryImageUploadDto;
 import hu.progmasters.bskinteriordesignbackend.gallery.service.GalleryImageService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.multipart.MultipartFile;
 
 
 @RestController
@@ -30,7 +31,7 @@ public class GalleryImageController {
 
     private final GalleryImageService galleryImageService;
 
-    @PostMapping(value = "/api/gallery/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @PostMapping(value = "/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<GalleryImageResponseDto> uploadGalleryImage(
             @ModelAttribute GalleryImageUploadDto command) {
@@ -42,7 +43,7 @@ public class GalleryImageController {
     @GetMapping("/paged")
     @Operation(summary = "Retrieve paginated gallery images")
     @ApiResponses({@ApiResponse(responseCode = "200", description = "Paginated list of gallery images")})
-    public ResponseEntity<Page<GalleryImageResponseDto>> getPagedGalleryImages(Pageable pageable) {
+    public ResponseEntity<Page<GalleryImageResponseDto>> getPagedGalleryImages(@Parameter(description = "Sort by field, e.g. 'displayOrder,asc'", example = "displayOrder,asc") @ParameterObject Pageable pageable) {
         log.info(CYAN + "HTTP GET paginated gallery images" + ANSI_RESET);
         Page<GalleryImageResponseDto> page = galleryImageService.getPagedImages(pageable);
         return ResponseEntity.ok(page);

--- a/src/main/java/hu/progmasters/bskinteriordesignbackend/gallery/controller/GalleryImageController.java
+++ b/src/main/java/hu/progmasters/bskinteriordesignbackend/gallery/controller/GalleryImageController.java
@@ -1,0 +1,69 @@
+package hu.progmasters.bskinteriordesignbackend.gallery.controller;
+
+import hu.progmasters.bskinteriordesignbackend.gallery.model.dto.GalleryImageResponseDto;
+import hu.progmasters.bskinteriordesignbackend.gallery.model.dto.GalleryImageUploadDto;
+import hu.progmasters.bskinteriordesignbackend.gallery.service.GalleryImageService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+
+@RestController
+@RequestMapping("/api/gallery")
+@Tag(name = "Gallery", description = "Endpoints related to gallery image management")
+@RequiredArgsConstructor
+@Slf4j
+public class GalleryImageController {
+
+    public static final String CYAN = "\u001B[36m";
+    public static final String ANSI_RESET = "\u001B[0m";
+
+    private final GalleryImageService galleryImageService;
+
+    @PostMapping
+    @PreAuthorize("hasRole('ADMIN')")
+    @Operation(summary = "Upload a new image to the gallery")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Image uploaded successfully"),
+            @ApiResponse(responseCode = "502", description = "Image upload failed due to Cloudinary error")
+    })
+    public ResponseEntity<GalleryImageResponseDto> uploadGalleryImage(@ModelAttribute GalleryImageUploadDto command) {
+        log.info(CYAN + "HTTP POST upload gallery image" + ANSI_RESET);
+        GalleryImageResponseDto response = galleryImageService.uploadImage(command);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/paged")
+    @Operation(summary = "Retrieve paginated gallery images")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Paginated list of gallery images")
+    })
+    public ResponseEntity<Page<GalleryImageResponseDto>> getPagedGalleryImages(Pageable pageable) {
+        log.info(CYAN + "HTTP GET paginated gallery images" + ANSI_RESET);
+        Page<GalleryImageResponseDto> page = galleryImageService.getPagedImages(pageable);
+        return ResponseEntity.ok(page);
+    }
+
+    @DeleteMapping("/{id}")
+    @PreAuthorize("hasRole('ADMIN')")
+    @Operation(summary = "Delete a gallery image by ID")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Image deleted successfully"),
+            @ApiResponse(responseCode = "404", description = "Image not found")
+    })
+    public ResponseEntity<Void> deleteGalleryImage(@PathVariable Long id) {
+        log.info(CYAN + "HTTP DELETE gallery image with ID: " + id + ANSI_RESET);
+        galleryImageService.deleteImage(id);
+        return ResponseEntity.ok().build();
+    }
+}
+
+

--- a/src/main/java/hu/progmasters/bskinteriordesignbackend/gallery/controller/GalleryImageController.java
+++ b/src/main/java/hu/progmasters/bskinteriordesignbackend/gallery/controller/GalleryImageController.java
@@ -11,9 +11,11 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 
 @RestController
@@ -28,24 +30,18 @@ public class GalleryImageController {
 
     private final GalleryImageService galleryImageService;
 
-    @PostMapping
+    @PostMapping(value = "/api/gallery/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @PreAuthorize("hasRole('ADMIN')")
-    @Operation(summary = "Upload a new image to the gallery")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "Image uploaded successfully"),
-            @ApiResponse(responseCode = "502", description = "Image upload failed due to Cloudinary error")
-    })
-    public ResponseEntity<GalleryImageResponseDto> uploadGalleryImage(@ModelAttribute GalleryImageUploadDto command) {
-        log.info(CYAN + "HTTP POST upload gallery image" + ANSI_RESET);
+    public ResponseEntity<GalleryImageResponseDto> uploadGalleryImage(
+            @ModelAttribute GalleryImageUploadDto command) {
+
         GalleryImageResponseDto response = galleryImageService.uploadImage(command);
         return ResponseEntity.ok(response);
     }
 
     @GetMapping("/paged")
     @Operation(summary = "Retrieve paginated gallery images")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "Paginated list of gallery images")
-    })
+    @ApiResponses({@ApiResponse(responseCode = "200", description = "Paginated list of gallery images")})
     public ResponseEntity<Page<GalleryImageResponseDto>> getPagedGalleryImages(Pageable pageable) {
         log.info(CYAN + "HTTP GET paginated gallery images" + ANSI_RESET);
         Page<GalleryImageResponseDto> page = galleryImageService.getPagedImages(pageable);
@@ -55,10 +51,7 @@ public class GalleryImageController {
     @DeleteMapping("/{id}")
     @PreAuthorize("hasRole('ADMIN')")
     @Operation(summary = "Delete a gallery image by ID")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "Image deleted successfully"),
-            @ApiResponse(responseCode = "404", description = "Image not found")
-    })
+    @ApiResponses({@ApiResponse(responseCode = "200", description = "Image deleted successfully"), @ApiResponse(responseCode = "404", description = "Image not found")})
     public ResponseEntity<Void> deleteGalleryImage(@PathVariable Long id) {
         log.info(CYAN + "HTTP DELETE gallery image with ID: " + id + ANSI_RESET);
         galleryImageService.deleteImage(id);

--- a/src/main/java/hu/progmasters/bskinteriordesignbackend/gallery/model/domain/GalleryImageEntity.java
+++ b/src/main/java/hu/progmasters/bskinteriordesignbackend/gallery/model/domain/GalleryImageEntity.java
@@ -19,6 +19,9 @@ public class GalleryImageEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(name = "display_order", nullable = false)
+    private Integer displayOrder;
+
     @Column(nullable = false)
     private String imageUrl;
 

--- a/src/main/java/hu/progmasters/bskinteriordesignbackend/gallery/model/domain/GalleryImageEntity.java
+++ b/src/main/java/hu/progmasters/bskinteriordesignbackend/gallery/model/domain/GalleryImageEntity.java
@@ -22,6 +22,9 @@ public class GalleryImageEntity {
     @Column(name = "display_order", nullable = false)
     private Integer displayOrder;
 
+    @Column(name = "cloudinary_public_id", nullable = false)
+    private String cloudinaryPublicId;
+
     @Column(nullable = false)
     private String imageUrl;
 

--- a/src/main/java/hu/progmasters/bskinteriordesignbackend/gallery/model/domain/GalleryImageEntity.java
+++ b/src/main/java/hu/progmasters/bskinteriordesignbackend/gallery/model/domain/GalleryImageEntity.java
@@ -1,0 +1,36 @@
+package hu.progmasters.bskinteriordesignbackend.gallery.model.domain;
+
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "gallery_image")
+@Getter
+@Setter
+@Builder(builderMethodName = "aGalleryImage", toBuilder = true, setterPrefix = "with")
+@NoArgsConstructor
+@AllArgsConstructor
+public class GalleryImageEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String imageUrl;
+
+    @Column(length = 255)
+    private String description;
+
+    @Column(nullable = false)
+    private LocalDateTime uploadedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        this.uploadedAt = LocalDateTime.now();
+    }
+
+}

--- a/src/main/java/hu/progmasters/bskinteriordesignbackend/gallery/model/dto/GalleryImageResponseDto.java
+++ b/src/main/java/hu/progmasters/bskinteriordesignbackend/gallery/model/dto/GalleryImageResponseDto.java
@@ -1,0 +1,23 @@
+package hu.progmasters.bskinteriordesignbackend.gallery.model.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder(builderMethodName = "aResponseDto", toBuilder = true, setterPrefix = "with")
+public class GalleryImageResponseDto {
+
+    @Schema(description = "Unique identifier of the image", example = "42")
+    private Long id;
+
+    @Schema(description = "Public URL of the uploaded image", example = "https://res.cloudinary.com/.../image.jpg")
+    private String imageUrl;
+
+    @Schema(description = "Optional description of the image", example = "Living room interior with natural light")
+    private String description;
+
+
+}

--- a/src/main/java/hu/progmasters/bskinteriordesignbackend/gallery/model/dto/GalleryImageUploadDto.java
+++ b/src/main/java/hu/progmasters/bskinteriordesignbackend/gallery/model/dto/GalleryImageUploadDto.java
@@ -1,0 +1,24 @@
+package hu.progmasters.bskinteriordesignbackend.gallery.model.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+import org.springframework.web.multipart.MultipartFile;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder(builderMethodName = "anUploadCommand", toBuilder = true, setterPrefix = "with")
+@Schema(name = "GalleryImageUploadCommand", description = "Payload for uploading a gallery image")
+public class GalleryImageUploadDto {
+
+    @Schema(description = "Image file to upload", required = true)
+    private MultipartFile file;
+
+    @Schema(description = "Optional description of the image", example = "Minimalist living room with light wood furniture and natural lighting")
+    private String description;
+
+
+}
+
+

--- a/src/main/java/hu/progmasters/bskinteriordesignbackend/gallery/model/dto/GalleryImageUploadDto.java
+++ b/src/main/java/hu/progmasters/bskinteriordesignbackend/gallery/model/dto/GalleryImageUploadDto.java
@@ -1,5 +1,6 @@
 package hu.progmasters.bskinteriordesignbackend.gallery.model.dto;
 
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -12,11 +13,12 @@ import org.springframework.web.multipart.MultipartFile;
 @Schema(name = "GalleryImageUploadCommand", description = "Payload for uploading a gallery image")
 public class GalleryImageUploadDto {
 
-    @Schema(description = "Image file to upload", required = true)
+    @Schema(type = "string", format = "binary", description = "Image file to upload", required = true)
     private MultipartFile file;
 
-    @Schema(description = "Optional description of the image", example = "Minimalist living room with light wood furniture and natural lighting")
+    @Schema(description = "Optional description of the image", example = "Minimalist living room with light wood furniture")
     private String description;
+
 
 
 }

--- a/src/main/java/hu/progmasters/bskinteriordesignbackend/gallery/repository/GalleryImageRepository.java
+++ b/src/main/java/hu/progmasters/bskinteriordesignbackend/gallery/repository/GalleryImageRepository.java
@@ -1,0 +1,12 @@
+package hu.progmasters.bskinteriordesignbackend.gallery.repository;
+
+
+import hu.progmasters.bskinteriordesignbackend.gallery.model.domain.GalleryImageEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface GalleryImageRepository extends JpaRepository<GalleryImageEntity, Long> {
+    Page<GalleryImageEntity> findAll(Pageable pageable);
+
+}

--- a/src/main/java/hu/progmasters/bskinteriordesignbackend/gallery/repository/GalleryImageRepository.java
+++ b/src/main/java/hu/progmasters/bskinteriordesignbackend/gallery/repository/GalleryImageRepository.java
@@ -6,7 +6,10 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface GalleryImageRepository extends JpaRepository<GalleryImageEntity, Long> {
     Page<GalleryImageEntity> findAll(Pageable pageable);
 
+    Optional<GalleryImageEntity> findTopByOrderByDisplayOrderDesc();
 }

--- a/src/main/java/hu/progmasters/bskinteriordesignbackend/gallery/service/GalleryImageService.java
+++ b/src/main/java/hu/progmasters/bskinteriordesignbackend/gallery/service/GalleryImageService.java
@@ -11,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
 
 @Service
@@ -23,13 +24,18 @@ public class GalleryImageService {
 
 
     public GalleryImageResponseDto uploadImage(GalleryImageUploadDto command) {
-        String imageUrl = cloudinaryService.uploadImage(command.getFile());
+        MultipartFile file = command.getFile();
+        String description = command.getDescription();
+
+        String imageUrl = cloudinaryService.uploadImage(file);
+
         GalleryImageEntity saved = galleryImageRepository.save(
                 GalleryImageEntity.aGalleryImage()
                         .withImageUrl(imageUrl)
-                        .withDescription(command.getDescription())
+                        .withDescription(description)
                         .build()
         );
+
         return GalleryImageResponseDto.aResponseDto()
                 .withId(saved.getId())
                 .withImageUrl(saved.getImageUrl())

--- a/src/main/java/hu/progmasters/bskinteriordesignbackend/gallery/service/GalleryImageService.java
+++ b/src/main/java/hu/progmasters/bskinteriordesignbackend/gallery/service/GalleryImageService.java
@@ -1,0 +1,56 @@
+package hu.progmasters.bskinteriordesignbackend.gallery.service;
+
+import hu.progmasters.bskinteriordesignbackend.cloudinary.CloudinaryService;
+import hu.progmasters.bskinteriordesignbackend.exception.GalleryImageNotFoundException;
+import hu.progmasters.bskinteriordesignbackend.gallery.model.domain.GalleryImageEntity;
+import hu.progmasters.bskinteriordesignbackend.gallery.model.dto.GalleryImageResponseDto;
+import hu.progmasters.bskinteriordesignbackend.gallery.model.dto.GalleryImageUploadDto;
+import hu.progmasters.bskinteriordesignbackend.gallery.repository.GalleryImageRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class GalleryImageService {
+
+    private final GalleryImageRepository galleryImageRepository;
+    private final CloudinaryService cloudinaryService;
+
+
+    public GalleryImageResponseDto uploadImage(GalleryImageUploadDto command) {
+        String imageUrl = cloudinaryService.uploadImage(command.getFile());
+        GalleryImageEntity saved = galleryImageRepository.save(
+                GalleryImageEntity.aGalleryImage()
+                        .withImageUrl(imageUrl)
+                        .withDescription(command.getDescription())
+                        .build()
+        );
+        return GalleryImageResponseDto.aResponseDto()
+                .withId(saved.getId())
+                .withImageUrl(saved.getImageUrl())
+                .withDescription(saved.getDescription())
+                .build();
+    }
+
+    public Page<GalleryImageResponseDto> getPagedImages(Pageable pageable) {
+        return galleryImageRepository.findAll(pageable)
+                .map(image -> GalleryImageResponseDto.aResponseDto()
+                        .withId(image.getId())
+                        .withImageUrl(image.getImageUrl())
+                        .withDescription(image.getDescription())
+                        .build());
+    }
+
+    public void deleteImage(Long id) {
+        GalleryImageEntity image = galleryImageRepository.findById(id)
+                .orElseThrow(() -> new GalleryImageNotFoundException(id));
+        galleryImageRepository.delete(image);
+    }
+}
+
+


### PR DESCRIPTION
### Summary
This PR implements the complete gallery feature with Cloudinary integration, paginated listing, image upload, and deletion.

### Features
- `GalleryImageController` with:
  - `GET /gallery`: paginated listing sorted by `displayOrder`
  - `POST /gallery`: image upload with description (multipart/form-data)
  - `DELETE /gallery/{id}`: image deletion with Cloudinary cleanup and order reindexing
- `GalleryImageEntity` with `displayOrder` and `cloudinaryPublicId` fields
- DTOs for upload and response, annotated with `@Schema` for Swagger
- `GalleryImageService` for business logic and delegation
- `GalleryImageRepository` with custom query for max `displayOrder`
- `CloudinaryService` for image upload and deletion
- Custom exceptions: `GalleryImageNotFoundException`, `CloudinaryUploadException`, `CloudinaryDeleteException`
- `GlobalExceptionHandler` for structured error responses

### Fixes & Improvements
- Swagger UI file upload support via `@ModelAttribute` and `@Schema(type = "string", format = "binary")`
- Resolved Hibernate type mismatch in repository method
- Reindexed `displayOrder` after deletion to maintain gallery integrity
- Verified successful Cloudinary upload and paginated response (200 OK)

### Dependencies
- Added `springdoc-openapi-starter-webmvc-ui:2.1.0` to `pom.xml`

### Motivation
Provides a scalable and admin-friendly gallery backend with clean API design, content integrity, and future extensibility (e.g. drag & drop ordering, image editing, categorization).