### PR TITLE
feat(about): Add profile image support to About section

### DIFF
--- a/src/main/java/hu/progmasters/bskinteriordesignbackend/about/controller/AboutController.java
+++ b/src/main/java/hu/progmasters/bskinteriordesignbackend/about/controller/AboutController.java
@@ -9,6 +9,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
@@ -35,10 +36,10 @@ public class AboutController {
     }
 
 
-    @PutMapping
+    @PutMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @PreAuthorize("hasRole('ADMIN')")
     @Operation(summary = "Updates the About section")
-    public ResponseEntity<Void> updateAbout(@Valid @RequestBody AboutUpdateDto command) {
+    public ResponseEntity<Void> updateAbout(@ModelAttribute AboutUpdateDto command) {
         log.info(CYAN + "HTTP PUT update About section" + ANSI_RESET);
         aboutService.updateContentSection(command);
         return ResponseEntity.ok().build();

--- a/src/main/java/hu/progmasters/bskinteriordesignbackend/about/controller/AboutController.java
+++ b/src/main/java/hu/progmasters/bskinteriordesignbackend/about/controller/AboutController.java
@@ -30,7 +30,7 @@ public class AboutController {
     @Operation(summary = "Retrieves the About section displayed on the frontend")
     public ResponseEntity<AboutResponseDto> getAbout() {
         log.info(CYAN + "HTTP GET About section" + ANSI_RESET);
-        AboutResponseDto responseDto = aboutService.getContent();
+        AboutResponseDto responseDto = aboutService.getContentSection();
         return new ResponseEntity<>(responseDto, HttpStatus.OK);
     }
 
@@ -40,7 +40,7 @@ public class AboutController {
     @Operation(summary = "Updates the About section")
     public ResponseEntity<Void> updateAbout(@Valid @RequestBody AboutUpdateDto command) {
         log.info(CYAN + "HTTP PUT update About section" + ANSI_RESET);
-        aboutService.updateContent(command);
+        aboutService.updateContentSection(command);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/hu/progmasters/bskinteriordesignbackend/about/controller/AboutController.java
+++ b/src/main/java/hu/progmasters/bskinteriordesignbackend/about/controller/AboutController.java
@@ -1,6 +1,6 @@
 package hu.progmasters.bskinteriordesignbackend.about.controller;
 
-import hu.progmasters.bskinteriordesignbackend.about.model.dto.AboutContentUpdateDto;
+import hu.progmasters.bskinteriordesignbackend.about.model.dto.AboutUpdateDto;
 import hu.progmasters.bskinteriordesignbackend.about.model.dto.AboutResponseDto;
 import hu.progmasters.bskinteriordesignbackend.about.service.AboutService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -27,18 +27,19 @@ public class AboutController {
 
 
     @GetMapping
-    @Operation(summary = "Retrieves the About section content displayed on the frontend")
-    public ResponseEntity<AboutResponseDto> getAboutContent() {
-        log.info(CYAN + "HTTP GET content for about section" + ANSI_RESET);
+    @Operation(summary = "Retrieves the About section displayed on the frontend")
+    public ResponseEntity<AboutResponseDto> getAbout() {
+        log.info(CYAN + "HTTP GET About section" + ANSI_RESET);
         AboutResponseDto responseDto = aboutService.getContent();
         return new ResponseEntity<>(responseDto, HttpStatus.OK);
     }
 
+
     @PutMapping
     @PreAuthorize("hasRole('ADMIN')")
-    @Operation(summary = "Update content of a specific About section entry")
-    public ResponseEntity<Void> updateAboutContent(@Valid @RequestBody AboutContentUpdateDto command) {
-        log.info(CYAN + "HTTP PUT update about content" + ANSI_RESET);
+    @Operation(summary = "Updates the About section")
+    public ResponseEntity<Void> updateAbout(@Valid @RequestBody AboutUpdateDto command) {
+        log.info(CYAN + "HTTP PUT update About section" + ANSI_RESET);
         aboutService.updateContent(command);
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/hu/progmasters/bskinteriordesignbackend/about/model/domain/AboutEntity.java
+++ b/src/main/java/hu/progmasters/bskinteriordesignbackend/about/model/domain/AboutEntity.java
@@ -21,4 +21,10 @@ public class AboutEntity {
     @Column(name = "content", columnDefinition = "TEXT")
     @Size(max = 5000)
     private String content;
+
+    @Column(name = "profile_image_url")
+    private String profileImageUrl;
+
+    @Column(name = "profile_image_public_id")
+    private String profileImagePublicId;
 }

--- a/src/main/java/hu/progmasters/bskinteriordesignbackend/about/model/dto/AboutResponseDto.java
+++ b/src/main/java/hu/progmasters/bskinteriordesignbackend/about/model/dto/AboutResponseDto.java
@@ -17,5 +17,6 @@ public class AboutResponseDto {
     @Schema(description = "Introductory text displayed on the frontend")
     private String content;
 
-
+    @Schema(description = "URL of the uploaded profile image")
+    private String profileImageUrl;
 }

--- a/src/main/java/hu/progmasters/bskinteriordesignbackend/about/model/dto/AboutUpdateDto.java
+++ b/src/main/java/hu/progmasters/bskinteriordesignbackend/about/model/dto/AboutUpdateDto.java
@@ -2,8 +2,10 @@ package hu.progmasters.bskinteriordesignbackend.about.model.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.*;
+import org.springframework.web.multipart.MultipartFile;
 
 @Getter
 @Setter
@@ -11,15 +13,16 @@ import lombok.*;
 @NoArgsConstructor
 @Builder(builderMethodName = "anUpdateCommand", toBuilder = true, setterPrefix = "with")
 @Schema(description = "Command object for updating the About section content")
-public class AboutContentUpdateDto {
+public class AboutUpdateDto {
 
     @Schema(description = "Unique identifier of the About section entry", example = "1")
     private Long id;
 
-
-    @NotBlank
     @Size(max = 5000)
     @Schema(description = "New content for the About section", example = "Welcome to our interior design studio...")
     private String content;
+
+    @Schema(type = "string", format = "binary", description = "Image file to upload")
+    private MultipartFile profileImage;
 
 }

--- a/src/main/java/hu/progmasters/bskinteriordesignbackend/about/service/AboutService.java
+++ b/src/main/java/hu/progmasters/bskinteriordesignbackend/about/service/AboutService.java
@@ -1,7 +1,7 @@
 package hu.progmasters.bskinteriordesignbackend.about.service;
 
 import hu.progmasters.bskinteriordesignbackend.about.model.domain.AboutEntity;
-import hu.progmasters.bskinteriordesignbackend.about.model.dto.AboutContentUpdateDto;
+import hu.progmasters.bskinteriordesignbackend.about.model.dto.AboutUpdateDto;
 import hu.progmasters.bskinteriordesignbackend.about.model.dto.AboutResponseDto;
 import hu.progmasters.bskinteriordesignbackend.about.repository.AboutRepository;
 import hu.progmasters.bskinteriordesignbackend.exception.AboutEntityNotFoundException;
@@ -27,7 +27,7 @@ public class AboutService {
                         .build());
     }
 
-    public void updateContent(AboutContentUpdateDto command) {
+    public void updateContent(AboutUpdateDto command) {
         AboutEntity about = aboutRepository.findById(command.getId())
                 .orElseThrow(() -> new AboutEntityNotFoundException(command.getId()));
         about.setContent(command.getContent());

--- a/src/main/java/hu/progmasters/bskinteriordesignbackend/about/service/AboutService.java
+++ b/src/main/java/hu/progmasters/bskinteriordesignbackend/about/service/AboutService.java
@@ -4,6 +4,8 @@ import hu.progmasters.bskinteriordesignbackend.about.model.domain.AboutEntity;
 import hu.progmasters.bskinteriordesignbackend.about.model.dto.AboutUpdateDto;
 import hu.progmasters.bskinteriordesignbackend.about.model.dto.AboutResponseDto;
 import hu.progmasters.bskinteriordesignbackend.about.repository.AboutRepository;
+import hu.progmasters.bskinteriordesignbackend.cloudinary.CloudinaryService;
+import hu.progmasters.bskinteriordesignbackend.cloudinary.model.dto.CloudinaryUploadResultDto;
 import hu.progmasters.bskinteriordesignbackend.exception.AboutEntityNotFoundException;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -15,21 +17,40 @@ import org.springframework.stereotype.Service;
 public class AboutService {
 
     private final AboutRepository aboutRepository;
+    private final CloudinaryService cloudinaryService;
 
-    public AboutResponseDto getContent() {
+
+    public AboutResponseDto getContentSection() {
         return aboutRepository.findTopByOrderByIdAsc()
                 .map(entity -> AboutResponseDto.anAboutResponse()
                         .withId(entity.getId())
                         .withContent(entity.getContent())
+                        .withProfileImageUrl(entity.getProfileImageUrl())
                         .build())
                 .orElse(AboutResponseDto.anAboutResponse()
                         .withContent("Default about content")
                         .build());
     }
 
-    public void updateContent(AboutUpdateDto command) {
+    public void updateContentSection(AboutUpdateDto command) {
         AboutEntity about = aboutRepository.findById(command.getId())
                 .orElseThrow(() -> new AboutEntityNotFoundException(command.getId()));
-        about.setContent(command.getContent());
+
+        if (command.getContent() != null && !command.getContent().isBlank()) {
+            about.setContent(command.getContent());
+        }
+
+        if (command.getProfileImage() != null && !command.getProfileImage().isEmpty()) {
+            CloudinaryUploadResultDto result = cloudinaryService.uploadImage(command.getProfileImage());
+
+            if (about.getProfileImagePublicId() != null) {
+                cloudinaryService.deleteImage(about.getProfileImagePublicId());
+            }
+
+            about.setProfileImageUrl(result.getImageUrl());
+            about.setProfileImagePublicId(result.getPublicId());
+        }
+
+        aboutRepository.save(about);
     }
 }


### PR DESCRIPTION
# Summary
This PR adds optional profile image upload functionality to the About section. It refactors DTO and controller naming for clarity, integrates Cloudinary for image management, and ensures compatibility with multipart/form-data requests in Swagger and frontend clients.

# Features
## Controller
• 	GET/about: returns current About content including profile image URL
• 	PUT/about: updates text content and optionally uploads a profile image ()
## Entity
• 	Added profileImageUrl to store the Cloudinary image URL
• 	Added profileImagePublicId to store the Cloudinary public ID for deletion
## DTOs
• 	Renamed AboutContentUpdateDto → AboutUodateDto
• 	Added MultipartFile profileImage field
• 	Annotated with @Schema(type = "string", format = "binary") for Swagger file upload support
## Service
• 	Injected CloudinaryService into AboutService
• 	Extended updateContentSection() to handle optional image upload and deletion
• 	Updated entity fields accordingly
• 	Included profileImageUrl in getContetSection() response
## Cloudinary Integration
• 	Uploads image and returns URL + public ID
• 	Deletes image by public ID

# Fixes & Improvements
• 	Switched controller from @RequestBody to @ModelAttribute for multipart/form-data compatibility
• 	Resolved 415 and 400 errors caused by incorrect content type and empty file input
• 	Verified successful image upload and content update (200 OK)
• 	Improved Swagger UI integration for file upload

# Dependencies
No new dependencies added (Cloudinary and Swagger already present)

# Motivation
This update provides a flexible and admin-friendly way to manage About section content, including optional profile image support. It ensures clean API design, robust error handling, and compatibility with Swagger and frontend form submissions. It also lays the groundwork for future enhancements such as image cropping, preview, or versioning.